### PR TITLE
TRAD-325 examples + do some transaction signature verification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,12 @@ jobs:
       - checkout:
           path: solana-trader-client-python
       - restore_cache:
-          key: deps-{{ .BRANCH }}-{{ checksum "~/ws/solana-trader-client-python/requirements.txt" }}
+          key: deps-{{ checksum "~/ws/solana-trader-client-python/requirements.txt" }}
+      - run:
+          name: Install awscli
+          command: |
+            sudo apt update
+            sudo apt install awscli
       - run:
           name: Install dependencies
           command: |
@@ -24,6 +29,7 @@ jobs:
             python -m virtualenv venv
             . venv/bin/activate
             pip install -r requirements.txt
+            make environment-integration
       - save_cache:
           key: deps-{{ checksum "~/ws/solana-trader-client-python/requirements.txt" }}
           paths:
@@ -80,7 +86,9 @@ workflows:
   version: 2
   test-branch:
     jobs:
-      - init
+      - init:
+          context:
+            - circleci
       - lint:
           requires:
             - init

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+test_state.json

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -1,7 +1,8 @@
 {
   "site_package_search_strategy": "all",
   "source_directories": [
-    "bxsolana"
+    "bxsolana",
+    "example"
   ],
   "ignore_all_errors": [
     "bxsolana/proto/"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: all clean pkg release proto lint fmt fmt-check analyze typecheck test
+.PHONY: environment-integration
 
 all: clean pkg
 
@@ -35,3 +36,6 @@ typecheck:
 
 test:
 	python -m unittest discover test/unit
+
+environment-integration:
+	aws s3 cp s3://files.bloxroute.com/trader-api/test_state.json $(CURDIR)/test_state.json

--- a/bxsolana/__init__.py
+++ b/bxsolana/__init__.py
@@ -9,8 +9,6 @@ async def trader_api(connection_provider: Provider) -> Provider:
     return connection_provider
 
 
-f: int = "123"
-
 __all__ = [
     "examples",
     "Provider",

--- a/bxsolana/__init__.py
+++ b/bxsolana/__init__.py
@@ -1,4 +1,5 @@
-from bxsolana import provider
+from . import provider
+from . import examples
 
 Provider = provider.Provider
 
@@ -8,4 +9,10 @@ async def trader_api(connection_provider: Provider) -> Provider:
     return connection_provider
 
 
-_all = ["trader_api", "Provider"]
+f: int = "123"
+
+__all__ = [
+    "examples",
+    "Provider",
+    "trader_api",
+]

--- a/bxsolana/examples/__init__.py
+++ b/bxsolana/examples/__init__.py
@@ -6,15 +6,20 @@ from .constants import (
     USDC_WALLET,
     OPEN_ORDERS,
     ORDER_ID,
-    SOL_USDC_MARKET,
+    MARKET,
 )
-from .order_utils import cancel_order, replace_order_by_client_order_i_d
+from .order_utils import (
+    cancel_order,
+    cancel_all_orders,
+    replace_order_by_client_order_i_d,
+)
 from .order_lifecycle import order_lifecycle
 
 __all__ = [
     "do_requests",
     "do_transaction_requests",
     "do_stream",
+    "cancel_all_orders",
     "cancel_order",
     "replace_order_by_client_order_i_d",
     "order_lifecycle",
@@ -22,5 +27,5 @@ __all__ = [
     "USDC_WALLET",
     "OPEN_ORDERS",
     "ORDER_ID",
-    "SOL_USDC_MARKET",
+    "MARKET",
 ]

--- a/bxsolana/examples/constants.py
+++ b/bxsolana/examples/constants.py
@@ -2,9 +2,9 @@
 # maintained by bloxroute team
 import json
 
-PUBLIC_KEY = "5ggt7wtjap91P3SPrFfi3QNuXRCn9D9oXcsNeRQH51q3"
-USDC_WALLET = "8w1igsiZfsWnMTJSKkSvDQYYCZyf6aXMihuXEYpxcZVD"
-OPEN_ORDERS = "4JCZomAb4eKcJQ9fqoi2JPT1TzjbhJEk8V8MmFKUQfnV"
+PUBLIC_KEY = "BgJ8uyf9yhLJaUVESRrqffzwVyQgRi9YvWmpEFaH14kw"
+USDC_WALLET = "6QRBKhLeJQNpPqRUz1L1nwARJ1YGsH3QpmVapn5PeWky"
+OPEN_ORDERS = "FpLJoV6WkBoAq7VRNWhfFCua64UZobfqyQG1z8ceTaz2"
 MARKET = "SOLUSDC"
 ORDER_ID = ""
 

--- a/bxsolana/examples/constants.py
+++ b/bxsolana/examples/constants.py
@@ -1,7 +1,21 @@
 # sample keys to run integration/regression tests with
-# maintained by bloxRoute team
-PUBLIC_KEY = "4JCZomAb4eKcJQ9fqoi2JPT1TzjbhJEk8V8MmFKUQfnV"
+# maintained by bloxroute team
+import json
+
+PUBLIC_KEY = "5ggt7wtjap91P3SPrFfi3QNuXRCn9D9oXcsNeRQH51q3"
 USDC_WALLET = "8w1igsiZfsWnMTJSKkSvDQYYCZyf6aXMihuXEYpxcZVD"
 OPEN_ORDERS = "4JCZomAb4eKcJQ9fqoi2JPT1TzjbhJEk8V8MmFKUQfnV"
-SOL_USDC_MARKET = "9wFFyRfZBsuAha4YcuxcXLKwMxJR43S7fPfQLusDBzvT"
-ORDER_ID = "3929156487700134707538850"
+MARKET = "SOLUSDC"
+ORDER_ID = ""
+
+try:
+    with open("test_state.json") as f:
+        cfg = json.load(f)
+        PUBLIC_KEY = cfg["publicKey"]
+        OPEN_ORDERS = cfg["openOrders"]
+        USDC_WALLET = cfg["usdcWallet"]
+        MARKET = cfg["market"]
+        ORDER_ID = cfg["expectedOrderId"]
+except Exception:
+    # ignore
+    pass

--- a/bxsolana/examples/order_utils.py
+++ b/bxsolana/examples/order_utils.py
@@ -112,18 +112,6 @@ async def settle_funds(
     )
 
 
-# async def place_order(p: provider.Provider,
-#                       owner_addr,
-#                       payer_addr,
-#                       market_addr,
-#                       order_side,
-#                       order_type,
-#                       order_amount,
-#                       order_price,
-#                       open_orders_addr,
-#                     )-> int:
-
-
 async def cancel_all_orders(
     p: provider.Provider,
     owner_addr,

--- a/bxsolana/examples/request_utils.py
+++ b/bxsolana/examples/request_utils.py
@@ -1,14 +1,15 @@
-import bxsolana
 from bxsolana_trader_proto import api as proto
+
+from .. import provider
 
 
 async def do_requests(
-    api: bxsolana.Provider,
-    public_key,
-    open_orders,
-    order_id,
-    usdc_wallet,
-    sol_usdc_market,
+    api: provider.Provider,
+    public_key: str,
+    open_orders: str,
+    order_id: str,
+    usdc_wallet: str,
+    sol_usdc_market: str,
 ):
     # markets API
     print("fetching all markets")
@@ -34,6 +35,37 @@ async def do_requests(
 
     print("fetching all tickers")
     print((await api.get_tickers(project=proto.Project.P_OPENBOOK)).to_json())
+
+    print("fetching prices")
+    print(
+        (
+            await api.get_price(
+                tokens=[
+                    "So11111111111111111111111111111111111111112",
+                    "USDC",
+                    "SOL",
+                    "USDT",
+                ]
+            )
+        ).to_json()
+    )
+
+    print("fetching pools")
+    print((await api.get_pools(projects=[proto.Project.P_RAYDIUM])).to_json())
+
+    print("fetching quotes")
+    print(
+        (
+            await api.get_quotes(
+                in_token="USDC",
+                out_token="SOL",
+                in_amount=0.01,
+                slippage=10,
+                limit=1,
+                projects=[proto.Project.P_RAYDIUM],
+            )
+        ).to_json()
+    )
 
     # trade API
     print("fetching open orders for account")
@@ -121,6 +153,7 @@ async def do_requests(
         )
     )
 
+    print("generate replace by client order id")
     print(
         (
             await api.post_replace_by_client_order_i_d(
@@ -140,6 +173,7 @@ async def do_requests(
         ).to_json()
     )
 
+    print("generate replace by order id")
     print(
         (
             await api.post_replace_order(
@@ -156,6 +190,39 @@ async def do_requests(
                 # optional, for identification
                 client_order_i_d=0,
                 order_i_d=order_id,
+            )
+        ).to_json()
+    )
+
+    print("generate trade swap")
+    print(
+        (
+            await api.post_trade_swap(
+                project=proto.Project.P_RAYDIUM,
+                owner_address=public_key,
+                in_token="SOL",
+                in_amount=0.01,
+                out_token="USDC",
+                slippage=0.01,
+            )
+        )
+    )
+
+    print("generate route swap")
+    step = proto.RouteStep(
+        in_token="USDC",
+        in_amount=0.01,
+        out_token="SOL",
+        out_amount=0.01,
+        out_amount_min=0.01,
+        project=proto.StepProject(label="Raydium", id="1234"),
+    )
+    print(
+        (
+            await api.post_route_trade_swap(
+                project=proto.Project.P_RAYDIUM,
+                owner_address=public_key,
+                steps=[step],
             )
         ).to_json()
     )

--- a/bxsolana/examples/stream_utils.py
+++ b/bxsolana/examples/stream_utils.py
@@ -64,19 +64,18 @@ async def do_stream(api: provider.Provider, run_slow: bool = False):
                 item_count = 0
                 break
 
-    if run_slow:
-        print("streaming price streams...")
-        async for response in api.get_prices_stream(
-            projects=[proto.Project.P_RAYDIUM],
-            tokens=[
-                "So11111111111111111111111111111111111111112",
-                "USDC",
-                "SOL",
-                "USDT",
-            ],
-        ):
-            print(response.to_json())
-            item_count += 1
-            if item_count == 1:
-                item_count = 0
-                break
+    print("streaming price streams...")
+    async for response in api.get_prices_stream(
+        projects=[proto.Project.P_RAYDIUM],
+        tokens=[
+            "So11111111111111111111111111111111111111112",
+            "USDC",
+            "SOL",
+            "USDT",
+        ],
+    ):
+        print(response.to_json())
+        item_count += 1
+        if item_count == 1:
+            item_count = 0
+            break

--- a/bxsolana/examples/stream_utils.py
+++ b/bxsolana/examples/stream_utils.py
@@ -1,8 +1,9 @@
-import bxsolana
 from bxsolana_trader_proto import api as proto
 
+from .. import provider
 
-async def do_stream(api: bxsolana.Provider, run_slow=False):
+
+async def do_stream(api: provider.Provider, run_slow: bool = False):
     item_count = 0
 
     if run_slow:
@@ -45,6 +46,34 @@ async def do_stream(api: bxsolana.Provider, run_slow=False):
             # RAY-SOL
             pools=["AVs9TA4nWDzfPJE9gGVNJMVhcQy3V9PGazuz33BfG2RA"],
             include_failed=True,
+        ):
+            print(response.to_json())
+            item_count += 1
+            if item_count == 1:
+                item_count = 0
+                break
+
+    if run_slow:
+        print("streaming pool reserves...")
+        async for response in api.get_pool_reserves_stream(
+            projects=[proto.Project.P_RAYDIUM]
+        ):
+            print(response.to_json())
+            item_count += 1
+            if item_count == 1:
+                item_count = 0
+                break
+
+    if run_slow:
+        print("streaming price streams...")
+        async for response in api.get_prices_stream(
+            projects=[proto.Project.P_RAYDIUM],
+            tokens=[
+                "So11111111111111111111111111111111111111112",
+                "USDC",
+                "SOL",
+                "USDT",
+            ],
         ):
             print(response.to_json())
             item_count += 1

--- a/bxsolana/examples/transaction_request_utils.py
+++ b/bxsolana/examples/transaction_request_utils.py
@@ -55,8 +55,8 @@ async def do_transaction_requests(
     print(signature)
 
     print(
-        "submitting replace order by client ID (generate + sign) to sell 0.1 SOL for USDC at 150_000"
-        " USD/SOL"
+        "submitting replace order by client ID (generate + sign) to sell 0.1"
+        " SOL for USDC at 150_000 USD/SOL"
     )
     print(
         await api.submit_replace_by_client_order_i_d(
@@ -77,8 +77,8 @@ async def do_transaction_requests(
     )
 
     print(
-        "submitting replace order (generate + sign) to sell 0.1 SOL for USDC at 150_000"
-        " USD/SOL"
+        "submitting replace order (generate + sign) to sell 0.1 SOL for USDC at"
+        " 150_000 USD/SOL"
     )
     print(
         await api.submit_replace_order(

--- a/bxsolana/examples/transaction_request_utils.py
+++ b/bxsolana/examples/transaction_request_utils.py
@@ -54,6 +54,50 @@ async def do_transaction_requests(
     client_order_id, signature = await submit_order()
     print(signature)
 
+    print(
+        "submitting replace order by client ID (generate + sign) to sell 0.1 SOL for USDC at 150_000"
+        " USD/SOL"
+    )
+    print(
+        await api.submit_replace_by_client_order_i_d(
+            owner_address=owner_addr,
+            payer_address=payer_addr,
+            market=market,
+            side=proto.Side.S_ASK,
+            types=[proto.OrderType.OT_LIMIT],
+            amount=0.1,
+            price=150_000,
+            project=proto.Project.P_SERUM,
+            # optional, but much faster if known
+            open_orders_address=open_orders_addr,
+            # optional, for identification
+            client_order_i_d=client_order_id,
+            skip_pre_flight=True,
+        )
+    )
+
+    print(
+        "submitting replace order (generate + sign) to sell 0.1 SOL for USDC at 150_000"
+        " USD/SOL"
+    )
+    print(
+        await api.submit_replace_order(
+            owner_address=owner_addr,
+            payer_address=payer_addr,
+            market=market,
+            side=proto.Side.S_ASK,
+            types=[proto.OrderType.OT_LIMIT],
+            amount=0.1,
+            price=150_000,
+            project=proto.Project.P_SERUM,
+            # optional, but much faster if known
+            open_orders_address=open_orders_addr,
+            # optional, for identification
+            client_order_id=0,
+            order_i_d=order_id,
+        )
+    )
+
     # cancel order example: comment out if want to try replace example
     print("submit cancel order")
     print(
@@ -91,52 +135,6 @@ async def do_transaction_requests(
             open_orders_address="",  # optional
         )
     )
-
-    # example won't work since order was cancelled; to demonstrate, comment out submit_cancel_by_client_order_i_d
-    # print(
-    #     "submitting replace order by client ID (generate + sign) to sell 0.1 SOL for USDC at 150_000"
-    #     " USD/SOL"
-    # )
-    # print(
-    #     await api.submit_replace_by_client_order_i_d(
-    #         owner_address=owner_addr,
-    #         payer_address=payer_addr,
-    #         market=market,
-    #         side=proto.Side.S_ASK,
-    #         types=[proto.OrderType.OT_LIMIT],
-    #         amount=0.1,
-    #         price=150_000,
-    #         project=proto.Project.P_SERUM,
-    #         # optional, but much faster if known
-    #         open_orders_address=open_orders_addr,
-    #         # optional, for identification
-    #         client_order_i_d=client_order_id,
-    #         skip_pre_flight=True,
-    #     )
-    # )
-
-    # example won't really work since order was already cancelled; to demonstrate, comment out submit_cancel_order
-    # print(
-    #     "submitting replace order (generate + sign) to sell 0.1 SOL for USDC at 150_000"
-    #     " USD/SOL"
-    # )
-    # print(
-    #     await api.submit_replace_order(
-    #         owner_address=owner_addr,
-    #         payer_address=payer_addr,
-    #         market=market,
-    #         side=proto.Side.S_ASK,
-    #         types=[proto.OrderType.OT_LIMIT],
-    #         amount=0.1,
-    #         price=150_000,
-    #         project=proto.Project.P_SERUM,
-    #         # optional, but much faster if known
-    #         open_orders_address=open_orders_addr,
-    #         # optional, for identification
-    #         client_order_id=0,
-    #         order_i_d=order_id,
-    #     )
-    # )
 
     print("creating transactions with memo")
     await create_transaction_with_memo(api)

--- a/bxsolana/examples/transaction_request_utils.py
+++ b/bxsolana/examples/transaction_request_utils.py
@@ -1,129 +1,148 @@
 import base64
+import random
+import sys
+from typing import Tuple
 
+from bxsolana_trader_proto import api as proto
 from solana.blockhash import Blockhash
 
-import bxsolana
-from bxsolana import transaction
-from bxsolana_trader_proto import api as proto
-
-from .constants import SOL_USDC_MARKET
+from .. import provider
+from .. import transaction
 
 
+# if you run this example with the integration wallet be sure to clean up your work afterward
 async def do_transaction_requests(
-    api: bxsolana.Provider,
-    run_trades,
-    owner_addr,
-    payer_addr,
-    open_orders_addr,
-    order_id,
-    usdc_wallet,
+    api: provider.Provider,
+    run_trades: bool,
+    owner_addr: str,
+    payer_addr: str,
+    open_orders_addr: str,
+    order_id: str,
+    usdc_wallet: str,
+    market: str,
 ):
     if not run_trades:
         print("skipping transaction requests: set by environment")
         return
 
-    print("creating transactions with memo")
-    await create_transaction_with_memo(api)
+    async def submit_order_with_client_id(client_id: int) -> str:
+        return await api.submit_order(
+            owner_address=owner_addr,
+            payer_address=payer_addr,
+            market=market,
+            side=proto.Side.S_ASK,
+            types=[proto.OrderType.OT_LIMIT],
+            amount=0.1,
+            price=150_000,
+            project=proto.Project.P_SERUM,
+            # optional, but much faster if known
+            open_orders_address=open_orders_addr,
+            # optional, for identification
+            client_order_id=client_id,
+        )
+
+    async def submit_order() -> Tuple[int, str]:
+        _client_order_id = random.randint(1, sys.maxsize)
+        _signature = await submit_order_with_client_id(_client_order_id)
+        return _client_order_id, _signature
 
     print(
         "submitting order (generate + sign) to sell 0.1 SOL for USDC at 150_000"
         " USD/SOL"
     )
-    print(
-        await api.submit_order(
-            owner_address=owner_addr,
-            payer_address=payer_addr,
-            market="SOLUSDC",
-            side=proto.Side.S_ASK,
-            types=[proto.OrderType.OT_LIMIT],
-            amount=0.1,
-            price=150_000,
-            project=proto.Project.P_OPENBOOK,
-            # optional, but much faster if known
-            open_orders_address=open_orders_addr,
-            # optional, for identification
-            client_order_id=0,
-        )
-    )
 
+    client_order_id, signature = await submit_order()
+    print(signature)
+
+    # cancel order example: comment out if want to try replace example
     print("submit cancel order")
     print(
         await api.submit_cancel_order(
             order_i_d=order_id,
             side=proto.Side.S_ASK,
-            market_address="SOLUSDC",
+            market_address=market,
             owner_address=owner_addr,
-            project=proto.Project.P_OPENBOOK,
+            project=proto.Project.P_SERUM,
             open_orders_address=open_orders_addr,
         )
     )
 
+    # cancel by client order ID example: comment out if want to try replace example
     print("submit cancel order by client ID")
     print(
         await api.submit_cancel_by_client_order_i_d(
-            client_order_i_d=123,
-            market_address=SOL_USDC_MARKET,
+            client_order_i_d=client_order_id,
+            market_address=market,
             owner_address=owner_addr,
-            project=proto.Project.P_OPENBOOK,
+            project=proto.Project.P_SERUM,
             open_orders_address=open_orders_addr,
+            skip_pre_flight=True,
         )
     )
+
     print("submit settle order")
     print(
         await api.submit_settle(
             owner_address=owner_addr,
-            market="SOLUSDC",
+            market=market,
             base_token_wallet=owner_addr,
             quote_token_wallet=usdc_wallet,
-            project=proto.Project.P_OPENBOOK,
+            project=proto.Project.P_SERUM,
             open_orders_address="",  # optional
         )
     )
 
-    print(
-        "submitting order (generate + sign) to sell 0.1 SOL for USDC at 150_000"
-        " USD/SOL"
-    )
-    print(
-        await api.submit_replace_by_client_order_i_d(
-            owner_address=owner_addr,
-            payer_address=payer_addr,
-            market="SOLUSDC",
-            side=proto.Side.S_ASK,
-            types=[proto.OrderType.OT_LIMIT],
-            amount=0.1,
-            price=150_000,
-            project=proto.Project.P_OPENBOOK,
-            # optional, but much faster if known
-            open_orders_address=open_orders_addr,
-            # optional, for identification
-            client_order_i_d=123,
-        )
-    )
-    print(
-        "submitting order (generate + sign) to sell 0.1 SOL for USDC at 150_000"
-        " USD/SOL"
-    )
-    print(
-        await api.submit_replace_order(
-            owner_address=owner_addr,
-            payer_address=payer_addr,
-            market="SOLUSDC",
-            side=proto.Side.S_ASK,
-            types=[proto.OrderType.OT_LIMIT],
-            amount=0.1,
-            price=150_000,
-            project=proto.Project.P_OPENBOOK,
-            # optional, but much faster if known
-            open_orders_address=open_orders_addr,
-            # optional, for identification
-            client_order_id=0,
-            order_i_d=order_id,
-        )
-    )
+    # example won't work since order was cancelled; to demonstrate, comment out submit_cancel_by_client_order_i_d
+    # print(
+    #     "submitting replace order by client ID (generate + sign) to sell 0.1 SOL for USDC at 150_000"
+    #     " USD/SOL"
+    # )
+    # print(
+    #     await api.submit_replace_by_client_order_i_d(
+    #         owner_address=owner_addr,
+    #         payer_address=payer_addr,
+    #         market=market,
+    #         side=proto.Side.S_ASK,
+    #         types=[proto.OrderType.OT_LIMIT],
+    #         amount=0.1,
+    #         price=150_000,
+    #         project=proto.Project.P_SERUM,
+    #         # optional, but much faster if known
+    #         open_orders_address=open_orders_addr,
+    #         # optional, for identification
+    #         client_order_i_d=client_order_id,
+    #         skip_pre_flight=True,
+    #     )
+    # )
+
+    # example won't really work since order was already cancelled; to demonstrate, comment out submit_cancel_order
+    # print(
+    #     "submitting replace order (generate + sign) to sell 0.1 SOL for USDC at 150_000"
+    #     " USD/SOL"
+    # )
+    # print(
+    #     await api.submit_replace_order(
+    #         owner_address=owner_addr,
+    #         payer_address=payer_addr,
+    #         market=market,
+    #         side=proto.Side.S_ASK,
+    #         types=[proto.OrderType.OT_LIMIT],
+    #         amount=0.1,
+    #         price=150_000,
+    #         project=proto.Project.P_SERUM,
+    #         # optional, but much faster if known
+    #         open_orders_address=open_orders_addr,
+    #         # optional, for identification
+    #         client_order_id=0,
+    #         order_i_d=order_id,
+    #     )
+    # )
+
+    print("creating transactions with memo")
+    await create_transaction_with_memo(api)
 
 
-async def create_transaction_with_memo(api: bxsolana.Provider):
+async def create_transaction_with_memo(api: provider.Provider):
     private_key = transaction.load_private_key_from_env()
 
     instruction = transaction.create_trader_api_memo_instruction("hi from dev")

--- a/example/provider/main.py
+++ b/example/provider/main.py
@@ -47,14 +47,14 @@ async def http():
 
     # either `try`/`finally` or `async with` work with each type of provider
     try:
-        await examples.do_requests(
-            api,
-            examples.PUBLIC_KEY,
-            examples.OPEN_ORDERS,
-            examples.ORDER_ID,
-            examples.USDC_WALLET,
-            examples.SOL_USDC_MARKET,
-        )
+        # await examples.do_requests(
+        #     api,
+        #     examples.PUBLIC_KEY,
+        #     examples.OPEN_ORDERS,
+        #     examples.ORDER_ID,
+        #     examples.USDC_WALLET,
+        #     examples.MARKET,
+        # )
         await examples.do_transaction_requests(
             api,
             RUN_TRADES,
@@ -63,6 +63,7 @@ async def http():
             examples.OPEN_ORDERS,
             examples.ORDER_ID,
             examples.USDC_WALLET,
+            examples.MARKET,
         )
     except Exception as e:
         print(e)
@@ -86,7 +87,7 @@ async def ws():
             examples.OPEN_ORDERS,
             examples.ORDER_ID,
             examples.USDC_WALLET,
-            examples.SOL_USDC_MARKET,
+            examples.MARKET,
         )
         await examples.do_transaction_requests(
             api,
@@ -96,6 +97,7 @@ async def ws():
             examples.OPEN_ORDERS,
             examples.ORDER_ID,
             examples.USDC_WALLET,
+            examples.MARKET,
         )
         await examples.do_stream(api, RUN_SLOW_STREAMS)
 
@@ -116,7 +118,7 @@ async def grpc():
             examples.OPEN_ORDERS,
             examples.ORDER_ID,
             examples.USDC_WALLET,
-            examples.SOL_USDC_MARKET,
+            examples.MARKET,
         )
         await examples.do_transaction_requests(
             api,
@@ -126,6 +128,7 @@ async def grpc():
             examples.OPEN_ORDERS,
             examples.ORDER_ID,
             examples.USDC_WALLET,
+            examples.MARKET,
         )
         await examples.do_stream(api, RUN_SLOW_STREAMS)
     finally:

--- a/example/transaction/main.py
+++ b/example/transaction/main.py
@@ -2,8 +2,7 @@ import asyncio
 import os
 
 from bxsolana_trader_proto import api as proto
-from bxsolana import provider
-from bxsolana import examples
+from bxsolana import provider, examples
 
 # TODO: Add some logic here to indicate to user if missing needed environment variables for tests
 public_key = os.getenv("PUBLIC_KEY")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 .
 build==0.8.0
 flake8==5.0.4
-pyre-check==0.9.15
+pyre-check==0.9.17


### PR DESCRIPTION
Also:
 - re-add missing examples from https://github.com/bloXroute-Labs/solana-trader-client-python/commit/064503b07c4568f3ca734a81cc893e159f8190af#diff-167f8e40754a29b22e2da9e0ca79327aa09514bac0999d068fbae98db4cd412f
 - add submit type implementations

Get the transaction examples runnable. They aren't run anywhere right now, but they should work again.