### PR TITLE
prevent accidental examples of orders with private key in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
       - run:
           name: Testnet
           command: |
+            export PRIVATE_KEY=""
             cd ~/ws/solana-trader-client-python
             . venv/bin/activate
             API_ENV=testnet AUTH_HEADER=$AUTH_HEADER_TESTNET python example/provider/main.py
@@ -79,6 +80,7 @@ jobs:
       - run:
           name: Mainnet
           command: |
+            export PRIVATE_KEY=""
             cd ~/ws/solana-trader-client-python
             . venv/bin/activate
             API_ENV=mainnet AUTH_HEADER=$AUTH_HEADER_MAINNET python example/provider/main.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - run:
           name: Testnet
           command: |
-            export PRIVATE_KEY=""
+            unset PRIVATE_KEY
             cd ~/ws/solana-trader-client-python
             . venv/bin/activate
             API_ENV=testnet AUTH_HEADER=$AUTH_HEADER_TESTNET python example/provider/main.py
@@ -80,7 +80,7 @@ jobs:
       - run:
           name: Mainnet
           command: |
-            export PRIVATE_KEY=""
+            unset PRIVATE_KEY
             cd ~/ws/solana-trader-client-python
             . venv/bin/activate
             API_ENV=mainnet AUTH_HEADER=$AUTH_HEADER_MAINNET python example/provider/main.py


### PR DESCRIPTION
it's a little bit too easy to do this right now. found some cases in the TS sdk as well