### PR TITLE
Update to support cpmm pools

### DIFF
--- a/bxsolana/examples/stream_utils.py
+++ b/bxsolana/examples/stream_utils.py
@@ -122,9 +122,23 @@ async def do_stream(api: provider.Provider, run_slow: bool = False):
                 break
 
     if run_slow:
-        print("streaming raydium new pool updates...")
+        if run_slow:
+            print("streaming raydium new pool updates without cpmm pools...")
+            async for response in api.get_new_raydium_pools_stream(
+                get_new_raydium_pools_request=proto.GetNewRaydiumPoolsRequest()
+            ):
+                print(response.to_json())
+                item_count += 1
+                if item_count == 1:
+                    item_count = 0
+                    break
+
+    if run_slow:
+        print("streaming raydium new pool updates with cpmm pools...")
         async for response in api.get_new_raydium_pools_stream(
-            get_new_raydium_pools_request=proto.GetNewRaydiumPoolsRequest()
+            get_new_raydium_pools_request=proto.GetNewRaydiumPoolsRequest(
+                include_cpmm=True
+            )
         ):
             print(response.to_json())
             item_count += 1

--- a/bxsolana/examples/transaction_request_utils.py
+++ b/bxsolana/examples/transaction_request_utils.py
@@ -33,7 +33,7 @@ async def do_transaction_requests(
             types=[OrderType.OT_LIMIT],
             amount=0.1,
             price=150_000,
-            project=proto.Project.P_SERUM,
+            project=proto.Project.P_OPENBOOK,
             # optional, but much faster if known
             open_orders_address=open_orders_addr,
             # optional, for identification
@@ -66,7 +66,7 @@ async def do_transaction_requests(
             types=[OrderType.OT_LIMIT],
             amount=0.1,
             price=150_000,
-            project=proto.Project.P_SERUM,
+            project=proto.Project.P_OPENBOOK,
             # optional, but much faster if known
             open_orders_address=open_orders_addr,
             # optional, for identification
@@ -88,7 +88,7 @@ async def do_transaction_requests(
             types=[OrderType.OT_LIMIT],
             amount=0.1,
             price=150_000,
-            project=proto.Project.P_SERUM,
+            project=proto.Project.P_OPENBOOK,
             # optional, but much faster if known
             open_orders_address=open_orders_addr,
             # optional, for identification

--- a/bxsolana/provider/constants.py
+++ b/bxsolana/provider/constants.py
@@ -1,6 +1,6 @@
 _mainnet_ny = "ny.solana.dex.blxrbdn.com"
 _mainnet_uk = "uk.solana.dex.blxrbdn.com"
-_testnet = "serum-nlb-5a2c3912804344a3.elb.us-east-1.amazonaws.com"
+_testnet = "solana.dex.bxrtest.com"
 _devnet = "solana-trader-api-nlb-6b0f765f2fc759e1.elb.us-east-1.amazonaws.com"
 
 
@@ -28,10 +28,10 @@ MAINNET_API_UK_GRPC_HOST = _mainnet_uk
 
 MAINNET_API_GRPC_PORT = 443
 
-TESTNET_API_HTTP = http_endpoint(_testnet, False)
-TESTNET_API_WS = ws_endpoint(_testnet, False)
+TESTNET_API_HTTP = http_endpoint(_testnet, True)
+TESTNET_API_WS = ws_endpoint(_testnet, True)
 TESTNET_API_GRPC_HOST = _testnet
-TESTNET_API_GRPC_PORT = 80
+TESTNET_API_GRPC_PORT = 443
 
 DEVNET_API_HTTP = http_endpoint(_devnet, False)
 DEVNET_API_WS = ws_endpoint(_devnet, False)

--- a/bxsolana/provider/http.py
+++ b/bxsolana/provider/http.py
@@ -88,19 +88,6 @@ class HttpProvider(Provider):
         ) as res:
             return await map_response(res, proto.GetTransactionResponse())
 
-    async def get_bundle_result_v2(
-        self,
-        get_bundle_result_request: proto.GetBundleResultRequest,
-        *,
-        timeout: Optional[float] = None,
-        deadline: Optional["Deadline"] = None,
-        metadata: Optional["MetadataLike"] = None,
-    ) -> proto.GetBundleResultResponse:
-        async with self._session.get(
-            f"{self._endpoint_v2}/bundle-result/{get_bundle_result_request.uuid}"
-        ) as res:
-            return await map_response(res, proto.GetBundleResultResponse())
-
     async def get_raydium_pools(
         self,
         get_raydium_pools_request: proto.GetRaydiumPoolsRequest,
@@ -655,7 +642,7 @@ class HttpProvider(Provider):
         # however we need clientOrderID (id is capitalized, not camelCase). This
         # code snippet will adjust the dictionary for us.
         json = post_order_request.to_dict()
-        jsonFixed = {"clientOrderID" if k == "clientOrderId" else k:v for k,v in json.items()}
+        jsonFixed = {"clientOrderID" if k == "clientOrderId" else k: v for k, v in json.items()}
         async with self._session.post(
             f"{self._endpoint}/trade/place", json=jsonFixed
         ) as res:

--- a/bxsolana/provider/http.py
+++ b/bxsolana/provider/http.py
@@ -651,8 +651,13 @@ class HttpProvider(Provider):
         deadline: Optional["Deadline"] = None,
         metadata: Optional["MetadataLike"] = None,
     ) -> proto.PostOrderResponse:
+        # the to_dict() call below will give use a field name of clientOrderId,
+        # however we need clientOrderID (id is capitalized, not camelCase). This
+        # code snippet will adjust the dictionary for us.
+        json = post_order_request.to_dict()
+        jsonFixed = {"clientOrderID" if k == "clientOrderId" else k:v for k,v in json.items()}
         async with self._session.post(
-            f"{self._endpoint}/trade/place", json=post_order_request.to_dict()
+            f"{self._endpoint}/trade/place", json=jsonFixed
         ) as res:
             return await map_response(res, proto.PostOrderResponse())
 

--- a/bxsolana/provider/http.py
+++ b/bxsolana/provider/http.py
@@ -642,7 +642,10 @@ class HttpProvider(Provider):
         # however we need clientOrderID (id is capitalized, not camelCase). This
         # code snippet will adjust the dictionary for us.
         json = post_order_request.to_dict()
-        jsonFixed = {"clientOrderID" if k == "clientOrderId" else k: v for k, v in json.items()}
+        jsonFixed = {
+            "clientOrderID" if k == "clientOrderId" else k: v
+            for k, v in json.items()
+        }
         async with self._session.post(
             f"{self._endpoint}/trade/place", json=jsonFixed
         ) as res:

--- a/example/bundles/main.py
+++ b/example/bundles/main.py
@@ -64,6 +64,7 @@ async def ws():
             f" {openbook_bundle_tx.transaction.content}"
         )
 
+
 async def grpc():
     print("\n*** GRPC Test ***\n")
     async with provider.grpc_testnet() as api:

--- a/example/bundles/main.py
+++ b/example/bundles/main.py
@@ -86,10 +86,10 @@ async def grpc():
 
         print(
             "created RAYDIUM swap tx with bundle tip of 1030:"
-            f" {raydium_bundle_tx.transaction.content}"
+            f" {raydium_bundle_tx.transactions[0].content}"
         )
 
-        signed_tx = signing.sign_tx(raydium_bundle_tx.transaction.content)
+        signed_tx = signing.sign_tx(raydium_bundle_tx.transactions[0].content)
 
         post_submit_response = await api.post_submit(
             post_submit_request=proto.PostSubmitRequest(
@@ -101,7 +101,7 @@ async def grpc():
 
         print(
             "submitted RAYDIUM tx with front running protection:"
-            f" {post_submit_response.transaction.content}"
+            f" {post_submit_response.signature}"
         )
 
         # get feedback about your bundle

--- a/example/bundles/main.py
+++ b/example/bundles/main.py
@@ -63,12 +63,6 @@ async def ws():
             "submitted OPENBOOK tx with front running protection:"
             f" {openbook_bundle_tx.transaction.content}"
         )
-        # get feedback about your bundle
-        print(
-            "current bundle status:"
-            f" {api.get_bundle_result_v2(post_submit_response.uuid)}"
-        )
-
 
 async def grpc():
     print("\n*** GRPC Test ***\n")
@@ -104,12 +98,6 @@ async def grpc():
             f" {post_submit_response.signature}"
         )
 
-        # get feedback about your bundle
-        print(
-            "current bundle status:"
-            f" {api.get_bundle_result_v2(post_submit_response.uuid)}"
-        )
-
 
 async def http():
     print("\n*** HTTP Test ***\n")
@@ -143,12 +131,6 @@ async def http():
         print(
             "submitted RAYDIUM tx with front running protection:"
             f" {post_submit_response.signature}"
-        )
-
-        # get feedback about your bundle
-        print(
-            "current bundle status:"
-            f" {api.get_bundle_result_v2(post_submit_response.uuid)}"
         )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ install_requires =
     solana==0.31.0
     solders==0.19.0
     bx-jsonrpc-py==0.2.0
-    bxsolana-trader-proto==0.0.70
+    bxsolana-trader-proto==0.0.71

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = bxsolana-trader
-version = 2.1.2
+version = 2.1.3
 description = Python SDK for bloXroute's Solana Trader API
 long_description = file: README.md, LICENSE
 long_description_content_type = text/markdown
@@ -23,4 +23,4 @@ install_requires =
     solana==0.31.0
     solders==0.19.0
     bx-jsonrpc-py==0.2.0
-    bxsolana-trader-proto==0.0.67
+    bxsolana-trader-proto==0.0.70


### PR DESCRIPTION
1. Updating library to v2.1.3 to reference bxsolana-trader-proto 0.0.70 with support for cpmm pools. 
2. Correcting bug in provider.http.post_order to correctly specify clientOrderID field name. 
3. Correcting several references to proto fields in example/bundles. 
4. Correcting examples.transaction_request_utils.py to reference correct project openbook (was serum) for order submission examples.
5. Additional example tests that were not working are being recorded to Jira.