### PR TITLE
adding examples for new pump amm pools endpoint

### DIFF
--- a/bxsolana/examples/stream_utils.py
+++ b/bxsolana/examples/stream_utils.py
@@ -190,3 +190,15 @@ async def do_stream(
             if item_count == 1:
                 item_count = 0
                 break
+
+    if run_slow:
+        print("streaming new pump swap amm pools")
+        async for response in api.get_pump_fun_new_amm_pool_stream(
+            get_pump_fun_new_amm_pool_stream_request=proto.GetPumpFunNewAmmPoolStreamRequest()
+        ):
+            print(response.to_json())
+            item_count+=1 
+            if item_count == 1:
+                item_count = 0
+                break
+

--- a/helpers.py
+++ b/helpers.py
@@ -433,6 +433,24 @@ async def get_trades_stream(p: provider.Provider) -> bool:
         return True if resp.trades is not None else False
     return False
 
+async def get_pump_fun_new_amm_pool_stream(p: provider.Provider) -> bool:
+    print("streaming new pump swap amm pools")
+
+    await p.close()
+
+    p = provider.grpc_pump_ny()
+    await p.connect()
+
+    async for resp in p.get_pump_fun_new_amm_pool_stream(
+        get_pump_fun_new_amm_pool_stream_request=proto.GetPumpFunNewAmmPoolStreamRequest()
+    ):
+        pprint(resp)
+        await p.close()
+
+        return True if resp.pool is not None else False
+
+    return False
+
 
 async def get_new_raydium_pools_stream(p: provider.Provider) -> bool:
     print("streaming raydium new pool updates without cpmm pools...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,6 @@ jaraco-classes~=3.4.0
 nest-asyncio~=1.6.0
 termcolor~=2.1.0
 bx-jsonrpc-py~=0.2.0
-bxsolana-trader-proto~=0.0.95
+bxsolana-trader-proto~=0.1.0
 async-timeout~=4.0.3
 prompt-toolkit~=3.0.48

--- a/sdk.py
+++ b/sdk.py
@@ -19,7 +19,8 @@ from helpers import Endpoint, get_markets, get_pools, get_tickers, get_raydium_c
     get_new_raydium_pools_stream_cpmm, get_recent_blockhash_stream, get_pool_reserve_stream, \
     get_block_stream, get_priority_fee, get_priority_fee_stream, get_bundle_tip_stream, get_priority_fee_by_program_stream, get_token_accounts, \
     call_trade_swap, call_route_trade_swap, call_raydium_trade_swap, call_raydium_cpmm_trade_swap, \
-    call_raydium_clmm_trade_swap, call_jupiter_trade_swap, call_pump_fun_trade_swap, create_personal_tx_and_submit, call_submit_snipe 
+    call_raydium_clmm_trade_swap, call_jupiter_trade_swap, call_pump_fun_trade_swap, create_personal_tx_and_submit, call_submit_snipe, \
+    get_pump_fun_new_amm_pool_stream
 
 nest_asyncio.apply()
 init(autoreset=True)
@@ -86,6 +87,8 @@ ExampleEndpoints = {
     "get_priority_fee_stream": Endpoint(func=get_priority_fee_stream, requires_additional_env_vars=False),
     "get_bundle_tip_stream": Endpoint(func=get_bundle_tip_stream, requires_additional_env_vars=False),
     "get_priority_fee_by_program_stream": Endpoint(func=get_priority_fee_by_program_stream,
+                                                  requires_additional_env_vars=False),
+    "get_pump_fun_new_amm_pool_stream": Endpoint(func=get_pump_fun_new_amm_pool_stream,
                                                   requires_additional_env_vars=False),
 
     # transaction endpoints

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = bxsolana-trader
-version = 2.2.2
+version = 2.2.3
 description = Python SDK for bloXroute's Solana Trader API
 long_description = file: README.md, LICENSE
 long_description_content_type = text/markdown
@@ -23,4 +23,4 @@ install_requires =
     solana==0.31.0
     solders==0.19.0
     bx-jsonrpc-py==0.2.0
-    bxsolana-trader-proto==0.0.99
+    bxsolana-trader-proto==0.1.0


### PR DESCRIPTION
## Added support for `GetPumpFunNewAmmPoolStream` endpoing

- Updated `requirements.txt` to use bxsolana-proto `v0.1.0` with stub support for `GetPumpFunNewAmmPoolStream` endpoint.
- Updated `setup.cfg` for new release `v2.2.3` with bxsoloana-proto at `v0.1.0`
- Updated `bxsolana/examples/stream_utils.py`, `helpers.py` and `sdk.py` with support for running an example usage.

*Will publish new release to PyPi after merge to `develop`*