### PR TITLE
Add timestamp automatically to submit methods; Increment pypi version for deployment; Increment bxtrader-proto version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ test_state.json
 .vscode/
 
 myenv
+**/.DS_Store

--- a/bxsolana/provider/base.py
+++ b/bxsolana/provider/base.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from bxsolana_trader_proto import api
 from bxsolana_trader_proto.common import OrderType
 from solders import keypair as kp     # pyre-ignore[21]: module is too hard to find
+from ..utils.timestamp import timestamp
 
 from .. import transaction
 
@@ -72,7 +73,7 @@ class Provider(api.ApiStub, ABC):
         )
         result = await self.post_submit(
             post_submit_request=api.PostSubmitRequest(
-                transaction=signed_tx, skip_pre_flight=skip_pre_flight
+                transaction=signed_tx, skip_pre_flight=skip_pre_flight, timestamp=timestamp()
             )
         )
         return result.signature
@@ -107,7 +108,7 @@ class Provider(api.ApiStub, ABC):
         )
         result = await self.post_submit(
             post_submit_request=api.PostSubmitRequest(
-                transaction=signed_tx, skip_pre_flight=skip_pre_flight
+                transaction=signed_tx, skip_pre_flight=skip_pre_flight, timestamp=timestamp()
             )
         )
         return result.signature
@@ -141,7 +142,7 @@ class Provider(api.ApiStub, ABC):
         )
         result = await self.post_submit(
             post_submit_request=api.PostSubmitRequest(
-                transaction=signed_tx, skip_pre_flight=skip_pre_flight
+                transaction=signed_tx, skip_pre_flight=skip_pre_flight, timestamp=timestamp()
             )
         )
         return result.signature
@@ -176,7 +177,7 @@ class Provider(api.ApiStub, ABC):
             signed_tx = transaction.sign_tx_message_with_private_key(tx, pk)
             result = await self.post_submit(
                 post_submit_request=api.PostSubmitRequest(
-                    transaction=signed_tx, skip_pre_flight=skip_pre_flight
+                    transaction=signed_tx, skip_pre_flight=skip_pre_flight, timestamp=timestamp()
                 )
             )
             signatures.append(result.signature)
@@ -213,7 +214,7 @@ class Provider(api.ApiStub, ABC):
         )
         result = await self.post_submit(
             post_submit_request=api.PostSubmitRequest(
-                transaction=signed_tx, skip_pre_flight=skip_pre_flight
+                transaction=signed_tx, skip_pre_flight=skip_pre_flight, timestamp=timestamp()
             )
         )
         return result.signature
@@ -256,7 +257,7 @@ class Provider(api.ApiStub, ABC):
         )
         result = await self.post_submit(
             post_submit_request=api.PostSubmitRequest(
-                transaction=signed_tx, skip_pre_flight=skip_pre_flight
+                transaction=signed_tx, skip_pre_flight=skip_pre_flight, timestamp=timestamp()
             )
         )
         return result.signature
@@ -301,7 +302,7 @@ class Provider(api.ApiStub, ABC):
         )
         result = await self.post_submit(
             post_submit_request=api.PostSubmitRequest(
-                transaction=signed_tx, skip_pre_flight=skip_pre_flight
+                transaction=signed_tx, skip_pre_flight=skip_pre_flight, timestamp=timestamp()
             )
         )
         return result.signature
@@ -347,7 +348,7 @@ class Provider(api.ApiStub, ABC):
 
         return await self.post_submit_batch(
             post_submit_batch_request=api.PostSubmitBatchRequest(
-                entries=signed_txs, submit_strategy=submit_strategy
+                entries=signed_txs, submit_strategy=submit_strategy, timestamp=timestamp()
             )
         )
 
@@ -388,7 +389,7 @@ class Provider(api.ApiStub, ABC):
 
         return await self.post_submit_batch(
             post_submit_batch_request=api.PostSubmitBatchRequest(
-                entries=signed_txs, submit_strategy=submit_strategy
+                entries=signed_txs, submit_strategy=submit_strategy, timestamp=timestamp()
             )
         )
 
@@ -422,7 +423,7 @@ class Provider(api.ApiStub, ABC):
 
         result = await self.post_submit(
             post_submit_request=api.PostSubmitRequest(
-                transaction=signed_tx, skip_pre_flight=skip_pre_flight
+                transaction=signed_tx, skip_pre_flight=skip_pre_flight, timestamp=timestamp()
             )
         )
 
@@ -458,7 +459,7 @@ class Provider(api.ApiStub, ABC):
 
         result = await self.post_submit(
             post_submit_request=api.PostSubmitRequest(
-                transaction=signed_tx, skip_pre_flight=skip_pre_flight
+                transaction=signed_tx, skip_pre_flight=skip_pre_flight, timestamp=timestamp()
             )
         )
 
@@ -494,7 +495,7 @@ class Provider(api.ApiStub, ABC):
 
         result = await self.post_submit(
             post_submit_request=api.PostSubmitRequest(
-                transaction=signed_tx, skip_pre_flight=skip_pre_flight
+                transaction=signed_tx, skip_pre_flight=skip_pre_flight, timestamp=timestamp()
             )
         )
 
@@ -530,7 +531,7 @@ class Provider(api.ApiStub, ABC):
 
         result = await self.post_submit(
             post_submit_request=api.PostSubmitRequest(
-                transaction=signed_tx, skip_pre_flight=skip_pre_flight
+                transaction=signed_tx, skip_pre_flight=skip_pre_flight, timestamp=timestamp()
             )
         )
 
@@ -568,7 +569,7 @@ class Provider(api.ApiStub, ABC):
 
         result = await self.post_submit(
             post_submit_request=api.PostSubmitRequest(
-                transaction=signed_tx, skip_pre_flight=skip_pre_flight
+                transaction=signed_tx, skip_pre_flight=skip_pre_flight, timestamp=timestamp()
             )
         )
 
@@ -595,7 +596,8 @@ class Provider(api.ApiStub, ABC):
             result = await self.post_submit_snipe_v2(
                 post_submit_snipe_request=api.PostSubmitSnipeRequest(
                     entries=entries,
-                    use_staked_rp_cs=use_staked_rpcs
+                    use_staked_rp_cs=use_staked_rpcs,
+                    timestamp=timestamp()
                 )
             )
             
@@ -615,7 +617,8 @@ class Provider(api.ApiStub, ABC):
                 transaction=api.TransactionMessageV2(
                     content=signed_tx
                 ),
-                revert_protection = revert_protection
+                revert_protection = revert_protection,
+                timestamp=timestamp()
             )
         )
         

--- a/bxsolana/provider/http.py
+++ b/bxsolana/provider/http.py
@@ -4,7 +4,6 @@ from typing import Type, AsyncGenerator, Optional, TYPE_CHECKING, List, Any
 import aiohttp
 
 from solders import keypair as kp  # pyre-ignore[21]: module is too hard to find
-import datetime
 
 from bxsolana_trader_proto import api as proto
 from grpclib.metadata import Deadline

--- a/bxsolana/provider/http.py
+++ b/bxsolana/provider/http.py
@@ -4,6 +4,7 @@ from typing import Type, AsyncGenerator, Optional, TYPE_CHECKING, List, Any
 import aiohttp
 
 from solders import keypair as kp  # pyre-ignore[21]: module is too hard to find
+import datetime
 
 from bxsolana_trader_proto import api as proto
 from grpclib.metadata import Deadline
@@ -13,6 +14,8 @@ from . import constants
 from .base import Provider
 from .http_error import map_response
 from .package_info import NAME, VERSION
+from ..utils.timestamp import timestamp_rfc3339
+
 
 if TYPE_CHECKING:
     # noinspection PyUnresolvedReferences,PyProtectedMember
@@ -880,8 +883,8 @@ class HttpProvider(Provider):
     ) -> proto.PostSubmitResponse:
         if transaction is None:
             raise ValueError("transaction cannot be omitted")
-
         post_submit_request_dict = post_submit_request.to_dict()
+        post_submit_request_dict["timestamp"] = timestamp_rfc3339()
         if "useStakedRpCs" in post_submit_request_dict:
             post_submit_request_dict["useStakedRPCs"] = (post_submit_request_dict.pop("useStakedRpCs"))
 
@@ -898,9 +901,11 @@ class HttpProvider(Provider):
         deadline: Optional["Deadline"] = None,
         metadata: Optional["MetadataLike"] = None,
     ) -> proto.PostSubmitBatchResponse:
+        post_submit_batch_request_dict = post_submit_batch_request.to_dict()
+        post_submit_batch_request_dict["timestamp"] = timestamp_rfc3339()
         async with self._session.post(
             f"{self._endpoint}/trade/submit-batch",
-            json=post_submit_batch_request.to_dict(),
+            json=post_submit_batch_request_dict,
         ) as res:
             return await map_response(res, proto.PostSubmitBatchResponse())
 
@@ -914,9 +919,10 @@ class HttpProvider(Provider):
     ) -> proto.PostSubmitResponse:
         if transaction is None:
             raise ValueError("transaction cannot be omitted")
-
+        post_submit_request_dict = post_submit_request.to_dict()
+        post_submit_request_dict["timestamp"] = timestamp_rfc3339()
         async with self._session.post(
-            f"{self._endpoint_v2}/submit", json=post_submit_request.to_dict()
+            f"{self._endpoint_v2}/submit", json=post_submit_request_dict
         ) as res:
             return await map_response(res, proto.PostSubmitResponse())
 
@@ -928,9 +934,11 @@ class HttpProvider(Provider):
         deadline: Optional["Deadline"] = None,
         metadata: Optional["MetadataLike"] = None,
     ) -> proto.PostSubmitBatchResponse:
+        post_submit_batch_request_dict = post_submit_batch_request.to_dict()
+        post_submit_batch_request_dict["timestamp"] = timestamp_rfc3339()
         async with self._session.post(
             f"{self._endpoint_v2}/submit-batch",
-            json=post_submit_batch_request.to_dict(),
+            json=post_submit_batch_request_dict,
         ) as res:
             return await map_response(res, proto.PostSubmitBatchResponse())
 
@@ -975,14 +983,14 @@ class HttpProvider(Provider):
         timeout: Optional[float] = None,
         deadline: Optional["Deadline"] = None,
     ) -> proto.PostSubmitResponse:
-        request_dict = post_submit_snipe_request.to_dict()
-
-        if "useStakedRpCs" in request_dict:
-            request_dict["useStakedRPCs"] = request_dict.pop("useStakedRpCs")
+        post_submit_snipe_request_dict = post_submit_snipe_request.to_dict()
+        post_submit_snipe_request_dict["timestamp"] = timestamp_rfc3339()
+        if "useStakedRpCs" in post_submit_snipe_request_dict:
+            post_submit_snipe_request_dict["useStakedRPCs"] = post_submit_snipe_request_dict.pop("useStakedRpCs")
 
         async with self._session.post(
             f"{self._endpoint_v2}/submit-snipe",
-            json=request_dict,
+            json=post_submit_snipe_request_dict,
         ) as res:
             return await map_response(res, proto.PostSubmitSnipeResponse())
         

--- a/bxsolana/utils/timestamp.py
+++ b/bxsolana/utils/timestamp.py
@@ -1,0 +1,45 @@
+import datetime
+from betterproto import Timestamp
+
+
+def timestamp():
+    """
+    Creates and returns a Protocol Buffer Timestamp object based on the current time.
+    
+    This function captures the current time and converts it to a Protocol Buffer
+    Timestamp object with seconds since epoch and nanoseconds precision.
+    
+    Returns:
+        Timestamp: A Protocol Buffer Timestamp object representing the current time
+                  with seconds and nanoseconds components.
+    """
+    now = datetime.datetime.now()
+    timestamp = Timestamp(
+        seconds=int(now.timestamp()),
+        nanos=now.microsecond * 1000
+    )
+    print(timestamp)
+    return timestamp
+
+
+def timestamp_rfc3339():
+    """
+    Returns the current time as an RFC 3339 formatted string suitable for
+    Protocol Buffer Timestamp JSON serialization.
+    
+    Reference: https://protobuf.dev/reference/php/api-docs/Google/Protobuf/Timestamp.html
+    
+    The format is: "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+    - All components except year are zero-padded to two digits
+    - Year is expressed using four digits
+    - Fractional seconds can go up to 9 digits (nanosecond precision)
+    - The "Z" suffix indicates UTC timezone
+    
+    Returns:
+        str: Current time in RFC 3339 format with UTC timezone (Z)
+    """
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    formatted_time = now.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + '000Z'
+    
+    return formatted_time

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ jaraco-classes~=3.4.0
 nest-asyncio~=1.6.0
 termcolor~=2.1.0
 bx-jsonrpc-py~=0.2.0
-bxsolana-trader-proto~=0.1.0
+bxsolana-trader-proto~=0.1.3
 async-timeout~=4.0.3
 prompt-toolkit~=3.0.48
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = bxsolana-trader
-version = 2.2.3
+version = 2.2.4
 description = Python SDK for bloXroute's Solana Trader API
 long_description = file: README.md, LICENSE
 long_description_content_type = text/markdown
@@ -23,4 +23,4 @@ install_requires =
     solana==0.31.0
     solders==0.19.0
     bx-jsonrpc-py==0.2.0
-    bxsolana-trader-proto==0.1.0
+    bxsolana-trader-proto>=0.1.3


### PR DESCRIPTION
Added timestamps automatically to all submit endpoints for GRPC, HTTP (via base) and HTTP.