### PR TITLE
add warnings for insecure and different endpoints for secure

### DIFF
--- a/bxsolana/provider/constants.py
+++ b/bxsolana/provider/constants.py
@@ -1,76 +1,134 @@
-from enum import Enum, auto
+from enum import Enum
+from typing import Tuple
 
-warning_tls_slowdown = "Performance Notice: Secure (TLS) endpoints may introduce latency due to handshake overhead. For optimal trading speed, consider using non-secure endpoints when appropriate."
+# Warning messages
+WARNING_TLS_SLOWDOWN = "Performance Notice: Secure (TLS) endpoints may introduce latency due to handshake overhead. For optimal trading speed, consider using non-secure endpoints when appropriate."
 
-_mainnet_ny = "ny.solana.dex.blxrbdn.com"
-_mainnet_uk = "uk.solana.dex.blxrbdn.com"
-_mainnet_la = "la.solana.dex.blxrbdn.com"
-_mainnet_frankfurt = "germany.solana.dex.blxrbdn.com"
-_mainnet_amsterdam = "amsterdam.solana.dex.blxrbdn.com"
-_mainnet_tokyo = "tokyo.solana.dex.blxrbdn.com"
-_mainnet_pump_ny = "pump-ny.solana.dex.blxrbdn.com"
-_mainnet_pump_uk = "pump-uk.solana.dex.blxrbdn.com"
-_testnet = "solana.dex.bxrtest.com"
-_devnet = "solana-trader-api-nlb-6b0f765f2fc759e1.elb.us-east-1.amazonaws.com"
-
-class Region(Enum):
-    NY="NY"
-    UK="UK"
-
-def http_endpoint(base: str, secure: bool) -> str:
-    prefix = "https" if secure else "http"
-    return f"{prefix}://{base}"
-
-def ws_endpoint(base: str, secure: bool) -> str:
-    prefix = "wss" if secure else "ws"
-    return f"{prefix}://{base}/ws"
-
-# GRPC defined as host and port
-MAINNET_API_GRPC_PORT = 80
-MAINNET_API_GRPC_PORT_SECURE = 443
-
-MAINNET_API_NY_GRPC_HOST = _mainnet_ny
-MAINNET_API_PUMP_NY_GRPC_HOST = _mainnet_pump_ny
-MAINNET_API_UK_GRPC_HOST = _mainnet_uk
-MAINNET_API_PUMP_UK_GRPC_HOST = _mainnet_uk
-MAINNET_API_LA_GRPC_HOST = _mainnet_la
-MAINNET_API_AMS_GRPC_HOST = _mainnet_amsterdam
-MAINNET_API_FRANKFURT_GRPC_HOST = _mainnet_frankfurt
-MAINNET_API_TOKYO_GRPC_HOST = _mainnet_tokyo
-
-_bases = {
-    "NY": _mainnet_ny,
-    "PUMP_NY": _mainnet_pump_ny,
-    "UK": _mainnet_uk,
-    "PUMP_UK": _mainnet_pump_uk,
-    "LA": _mainnet_la,
-    "AMS": _mainnet_amsterdam,
-    "TOKYO": _mainnet_tokyo,
-    "FRANKFURT": _mainnet_frankfurt,
+# Base hostnames
+_HOSTS = {
+    "ny": "ny.solana.dex.blxrbdn.com",
+    "uk": "uk.solana.dex.blxrbdn.com", 
+    "la": "la.solana.dex.blxrbdn.com",
+    "frankfurt": "germany.solana.dex.blxrbdn.com",
+    "amsterdam": "amsterdam.solana.dex.blxrbdn.com",
+    "tokyo": "tokyo.solana.dex.blxrbdn.com",
+    "pump_ny": "pump-ny.solana.dex.blxrbdn.com",
+    "pump_uk": "pump-uk.solana.dex.blxrbdn.com",
+    "testnet": "solana.dex.bxrtest.com",
+    "devnet": "solana-trader-api-nlb-6b0f765f2fc759e1.elb.us-east-1.amazonaws.com",
 }
 
-# Create insecure endpoints
-for key, base in _bases.items():
-    globals()[f"MAINNET_API_{key}_HTTP"] = http_endpoint(base, False)
-    globals()[f"MAINNET_API_{key}_WS"] = ws_endpoint(base, False)
+class Region(Enum):
+    NY = "NY"
+    UK = "UK"
+    LA = "LA"
+    AMS = "AMS"
+    TOKYO = "TOKYO"
+    FRANKFURT = "FRANKFURT"
 
-# Create secure endpoints
-for key, base in _bases.items():
-    globals()[f"MAINNET_API_{key}_HTTP_SECURE"] = http_endpoint(base, True)
-    globals()[f"MAINNET_API_{key}_WS_SECURE"] = ws_endpoint(base, True)
+class ConnectionType(Enum):
+    GRPC = "gRPC"
+    HTTP = "HTTP" 
+    WS = "WS"
 
-# Testnet and Devnet
-TESTNET_API_HTTP = http_endpoint(_testnet, True)
-TESTNET_API_WS = ws_endpoint(_testnet, True)
-TESTNET_API_GRPC_HOST = _testnet
-TESTNET_API_GRPC_PORT = 443
+# Port constants
+GRPC_PORT_INSECURE = 80
+GRPC_PORT_SECURE = 443
+TESTNET_GRPC_PORT = 443
+DEVNET_GRPC_PORT = 80
+LOCAL_GRPC_PORT = 9000
 
-DEVNET_API_HTTP = http_endpoint(_devnet, False)
-DEVNET_API_WS = ws_endpoint(_devnet, False)
-DEVNET_API_GRPC_HOST = _devnet
-DEVNET_API_GRPC_PORT = 80
+def _build_endpoint(host: str, connection: ConnectionType, secure: bool) -> str:
+    """Build endpoint URL based on connection type and security."""
+    if connection == ConnectionType.HTTP:
+        prefix = "https" if secure else "http"
+        return f"{prefix}://{host}"
+    elif connection == ConnectionType.WS:
+        prefix = "wss" if secure else "ws"
+        return f"{prefix}://{host}/ws"
+    else:
+        raise ValueError(f"Unsupported connection type for URL building: {connection}")
 
-LOCAL_API_HTTP = "http://127.0.0.1:9000"
-LOCAL_API_WS = "ws://127.0.0.1:9000/ws"
-LOCAL_API_GRPC_HOST = "127.0.0.1"
-LOCAL_API_GRPC_PORT = 9000
+def get_endpoint(region: Region, connection: ConnectionType, secure: bool = True, pump: bool = False) -> str | Tuple[str, int]:
+    """
+    Get endpoint for specified region, connection type, and TLS settings.
+    
+    Args:
+        region: Target region
+        connection: Connection type (HTTP, WS, or GRPC)
+        secure: Whether to use secure connection
+        pump: Whether to use pump-specific endpoints
+        
+    Returns:
+        For HTTP/WS: URL string
+        For GRPC: Tuple of (host, port)
+    """
+    # Handle pump endpoints
+    if pump:
+        if region == Region.NY:
+            host = _HOSTS["pump_ny"]
+        elif region == Region.UK:
+            host = _HOSTS["pump_uk"]
+        else:
+            raise ValueError(f"Pump endpoints not supported for region {region.value}")
+    else:
+        # Map regions to hosts
+        region_map = {
+            Region.NY: _HOSTS["ny"],
+            Region.UK: _HOSTS["uk"],
+            Region.LA: _HOSTS["la"],
+            Region.AMS: _HOSTS["amsterdam"],
+            Region.TOKYO: _HOSTS["tokyo"],
+            Region.FRANKFURT: _HOSTS["frankfurt"],
+        }
+        
+        if region not in region_map:
+            raise ValueError(f"Unknown region: {region.value}")
+        
+        host = region_map[region]
+    
+    # Return based on connection type
+    if connection == ConnectionType.GRPC:
+        port = GRPC_PORT_SECURE if secure else GRPC_PORT_INSECURE
+        return host, port
+    else:
+        return _build_endpoint(host, connection, secure)
+
+# Convenience functions for backward compatibility
+def get_grpc_endpoint(region: Region, secure: bool = False, pump: bool = False) -> Tuple[str, int]:
+    """Get GRPC endpoint as (host, port) tuple."""
+    return get_endpoint(region, ConnectionType.GRPC, secure, pump)
+
+def get_http_endpoint(region: Region, secure: bool = False, pump: bool = False) -> str:
+    """Get HTTP endpoint URL."""
+    return get_endpoint(region, ConnectionType.HTTP, secure, pump)
+
+def get_ws_endpoint(region: Region, secure: bool = False, pump: bool = False) -> str:
+    """Get WebSocket endpoint URL."""
+    return get_endpoint(region, ConnectionType.WS, secure, pump)
+
+# Special environment endpoints
+def get_testnet_endpoint(connection: ConnectionType, secure: bool = False) -> str | Tuple[str, int]:
+    """Get testnet endpoint (always secure)."""
+    host = _HOSTS["testnet"]
+    if connection == ConnectionType.GRPC:
+        return host, TESTNET_GRPC_PORT
+    else:
+        return _build_endpoint(host, connection, secure=secure)
+
+def get_devnet_endpoint(connection: ConnectionType, secure: bool = False) -> str | Tuple[str, int]:
+    """Get devnet endpoint (always insecure)."""
+    host = _HOSTS["devnet"]
+    if connection == ConnectionType.GRPC:
+        return host, DEVNET_GRPC_PORT
+    else:
+        return _build_endpoint(host, connection, secure=secure)
+
+def get_local_endpoint(connection: ConnectionType) -> str | Tuple[str, int]:
+    """Get local development endpoint."""
+    if connection == ConnectionType.GRPC:
+        return "127.0.0.1", LOCAL_GRPC_PORT
+    elif connection == ConnectionType.HTTP:
+        return "http://127.0.0.1:9000"
+    elif connection == ConnectionType.WS:
+        return "ws://127.0.0.1:9000/ws"

--- a/bxsolana/provider/constants.py
+++ b/bxsolana/provider/constants.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, auto
 
 warning_tls_slowdown = "Performance Notice: Secure (TLS) endpoints may introduce latency due to handshake overhead. For optimal trading speed, consider using non-secure endpoints when appropriate."
 
@@ -12,6 +12,10 @@ _mainnet_pump_ny = "pump-ny.solana.dex.blxrbdn.com"
 _mainnet_pump_uk = "pump-uk.solana.dex.blxrbdn.com"
 _testnet = "solana.dex.bxrtest.com"
 _devnet = "solana-trader-api-nlb-6b0f765f2fc759e1.elb.us-east-1.amazonaws.com"
+
+class Region(Enum):
+    NY="NY"
+    UK="UK"
 
 def http_endpoint(base: str, secure: bool) -> str:
     prefix = "https" if secure else "http"

--- a/bxsolana/provider/constants.py
+++ b/bxsolana/provider/constants.py
@@ -1,4 +1,6 @@
-from enum import Enum, auto
+from enum import Enum
+
+warning_tls_slowdown = "Performance Notice: Secure (TLS) endpoints may introduce latency due to handshake overhead. For optimal trading speed, consider using non-secure endpoints when appropriate."
 
 _mainnet_ny = "ny.solana.dex.blxrbdn.com"
 _mainnet_uk = "uk.solana.dex.blxrbdn.com"
@@ -11,65 +13,49 @@ _mainnet_pump_uk = "pump-uk.solana.dex.blxrbdn.com"
 _testnet = "solana.dex.bxrtest.com"
 _devnet = "solana-trader-api-nlb-6b0f765f2fc759e1.elb.us-east-1.amazonaws.com"
 
-class Region(Enum):
-    NY = "NY"
-    UK = "UK"
-
 def http_endpoint(base: str, secure: bool) -> str:
-    prefix = "http"
-    if secure:
-        prefix = "https"
+    prefix = "https" if secure else "http"
     return f"{prefix}://{base}"
 
-
 def ws_endpoint(base: str, secure: bool) -> str:
-    prefix = "ws"
-    if secure:
-        prefix = "wss"
+    prefix = "wss" if secure else "ws"
     return f"{prefix}://{base}/ws"
 
+# GRPC defined as host and port
+MAINNET_API_GRPC_PORT = 80
+MAINNET_API_GRPC_PORT_SECURE = 443
 
-MAINNET_API_GRPC_PORT = 443
-
-
-# TODO: Create Provider level functionality based on region type
-MAINNET_API_NY_HTTP = http_endpoint(_mainnet_ny, True)
-MAINNET_API_NY_WS = ws_endpoint(_mainnet_ny, True)
 MAINNET_API_NY_GRPC_HOST = _mainnet_ny
-
-MAINNET_API_UK_HTTP = http_endpoint(_mainnet_uk, True)
-MAINNET_API_UK_WS = ws_endpoint(_mainnet_uk, True)
-MAINNET_API_UK_GRPC_HOST = _mainnet_uk
-
-# Pump Only Regions
-# The following URLs are used for Trader API instances that support Pump Fun streams (Raydium is disabled)
-# Not all documented trader API endpoints are supported
-# See documentation: https://docs.bloxroute.com/solana/trader-api/introduction
-MAINNET_API_PUMP_NY_HTTP = http_endpoint(_mainnet_pump_ny, True)
-MAINNET_API_PUMP_NY_WS = ws_endpoint(_mainnet_pump_ny, True)
 MAINNET_API_PUMP_NY_GRPC_HOST = _mainnet_pump_ny
-
-# Submit Only Regions
-# Most functionality of Solana Trader API is disabled on the following URLs, however they give coverage to
-# tx submissions in many different endpoints in the world
-# see documentation: https://docs.bloxroute.com/solana/trader-api/introduction/regions
-MAINNET_API_LA_HTTP = http_endpoint(_mainnet_la, True)
-MAINNET_API_LA_WS = ws_endpoint(_mainnet_la, True)
+MAINNET_API_UK_GRPC_HOST = _mainnet_uk
+MAINNET_API_PUMP_UK_GRPC_HOST = _mainnet_uk
 MAINNET_API_LA_GRPC_HOST = _mainnet_la
-
-MAINNET_API_AMS_HTTP = http_endpoint(_mainnet_amsterdam, True)
-MAINNET_API_AMS_WS = ws_endpoint(_mainnet_amsterdam, True)
 MAINNET_API_AMS_GRPC_HOST = _mainnet_amsterdam
-
-MAINNET_API_TOKYO_HTTP = http_endpoint(_mainnet_tokyo, True)
-MAINNET_API_TOKYO_WS = ws_endpoint(_mainnet_tokyo, True)
+MAINNET_API_FRANKFURT_GRPC_HOST = _mainnet_frankfurt
 MAINNET_API_TOKYO_GRPC_HOST = _mainnet_tokyo
 
-MAINNET_API_FRANKFURT_HTTP = http_endpoint(_mainnet_frankfurt, True)
-MAINNET_API_FRANKFURT_WS = ws_endpoint(_mainnet_frankfurt, True)
-MAINNET_API_FRANKFURT_GRPC_HOST = _mainnet_frankfurt
+_bases = {
+    "NY": _mainnet_ny,
+    "PUMP_NY": _mainnet_pump_ny,
+    "UK": _mainnet_uk,
+    "PUMP_UK": _mainnet_pump_uk,
+    "LA": _mainnet_la,
+    "AMS": _mainnet_amsterdam,
+    "TOKYO": _mainnet_tokyo,
+    "FRANKFURT": _mainnet_frankfurt,
+}
 
-# TESTNET and DEVNET are not stable - Please use with caution
+# Create insecure endpoints
+for key, base in _bases.items():
+    globals()[f"MAINNET_API_{key}_HTTP"] = http_endpoint(base, False)
+    globals()[f"MAINNET_API_{key}_WS"] = ws_endpoint(base, False)
+
+# Create secure endpoints
+for key, base in _bases.items():
+    globals()[f"MAINNET_API_{key}_HTTP_SECURE"] = http_endpoint(base, True)
+    globals()[f"MAINNET_API_{key}_WS_SECURE"] = ws_endpoint(base, True)
+
+# Testnet and Devnet
 TESTNET_API_HTTP = http_endpoint(_testnet, True)
 TESTNET_API_WS = ws_endpoint(_testnet, True)
 TESTNET_API_GRPC_HOST = _testnet

--- a/bxsolana/provider/grpc.py
+++ b/bxsolana/provider/grpc.py
@@ -3,6 +3,7 @@ import warnings
 from typing import Optional
 
 from grpclib import client
+from grpclib.config import Configuration
 from solders import keypair as kp # pyre-ignore[21]: module is too hard to find
 
 from .. import transaction
@@ -59,8 +60,14 @@ class GrpcProvider(Provider):
 
     async def connect(self):
         if self.channel is None:
+            config = Configuration(
+                _keepalive_time=15.0,
+                _keepalive_timeout=5.0,
+                _keepalive_permit_without_calls=True,  # PermitWithoutStream equivalent
+            )
+
             self.channel = client.Channel(
-                self._host, self._port, ssl=self._use_ssl
+                self._host, self._port, ssl=self._use_ssl, config=config
             )
             self.metadata = {
                 "authorization": self._auth_header,

--- a/bxsolana/provider/grpc.py
+++ b/bxsolana/provider/grpc.py
@@ -23,8 +23,8 @@ class GrpcProvider(Provider):
 
     def __init__(
         self,
-        host: str = constants.MAINNET_API_NY_GRPC_HOST,
-        port: int = constants.MAINNET_API_GRPC_PORT,
+        host: str = constants._HOSTS["ny"],
+        port: int = constants.GRPC_PORT_INSECURE,
         private_key: Optional[str] = None,
         auth_header: Optional[str] = None,
         use_ssl: bool = False,
@@ -32,7 +32,8 @@ class GrpcProvider(Provider):
         timeout: Optional[float] = None,
     ):
         if use_ssl:
-            warnings.warn(constants.warning_tls_slowdown)
+             warnings.warn(constants.WARNING_TLS_SLOWDOWN)
+             
         self._host = host
         self._port = port
         self._use_ssl = use_ssl
@@ -64,60 +65,76 @@ class GrpcProvider(Provider):
             self.metadata = {
                 "authorization": self._auth_header,
                 "x-sdk": NAME,
-                "s-sdk-version": VERSION,
+                "x-sdk-version": VERSION,
             }
 
     def private_key(self) -> Optional[kp.Keypair]:
         return self._private_key
 
     async def close(self):
-        channel = self.channel
-        if channel is not None:
+        if self.channel is not None:
             self.channel.close()
+            self.channel = None
 
 
-def grpc(auth_header: Optional[str] = None, region: Optional[constants.Region] = None) -> GrpcProvider:
-    # Default to UK if no region specified
-    if region is None or region == constants.Region.UK:
-        host = constants.MAINNET_API_UK_GRPC_HOST
-    elif region == constants.Region.NY:
-        host = constants.MAINNET_API_NY_GRPC_HOST
-    else:
-        raise ValueError(f"Unsupported region: {region}")
-
+def grpc(auth_header: Optional[str] = None, private_key: Optional[str] = None, region: Optional[constants.Region] = constants.Region.NY, secure: Optional[bool] = False) -> GrpcProvider:
+    host, port = constants.get_grpc_endpoint(region, secure)
     return GrpcProvider(
         host=host,
-        port=constants.MAINNET_API_GRPC_PORT,
-        use_ssl=True
+        port=port,
+        use_ssl=secure,
+        private_key=private_key,
+        auth_header=auth_header
     )
 
-def grpc_pump_ny(auth_header: Optional[str] = None) -> Provider:
+def grpc_pump_ny(auth_header: Optional[str] = None, private_key: Optional[str] = None, secure: Optional[bool] = False) -> Provider:
+    host, port = constants.get_grpc_endpoint(constants.Region.NY, secure, pump=True)
     return GrpcProvider(
-        host=constants.MAINNET_API_PUMP_NY_GRPC_HOST,
+        host=host,
+        port=port,
         auth_header=auth_header,
-        use_ssl=True,
+        private_key=private_key,
+        use_ssl=secure,
     )
 
-
-def grpc_testnet(auth_header: Optional[str] = None) -> Provider:
+def grpc_pump_uk(auth_header: Optional[str] = None, private_key: Optional[str] = None, secure: Optional[bool] = False) -> Provider:
+    host, port = constants.get_grpc_endpoint(constants.Region.UK, secure, pump=True)
     return GrpcProvider(
-        host=constants.TESTNET_API_GRPC_HOST,
-        port=constants.TESTNET_API_GRPC_PORT,
+        host=host,
+        port=port,
         auth_header=auth_header,
+        private_key=private_key,
+        use_ssl=secure,
     )
 
 
-def grpc_devnet(auth_header: Optional[str] = None) -> Provider:
+def grpc_testnet(auth_header: Optional[str] = None, private_key: Optional[str] = None, secure: Optional[bool] = False) -> Provider:
+    host, port = constants.get_testnet_endpoint(constants.ConnectionType.GRPC, secure=secure)
     return GrpcProvider(
-        host=constants.DEVNET_API_GRPC_HOST,
-        port=constants.DEVNET_API_GRPC_PORT,
+        host=host,
+        port=port,
         auth_header=auth_header,
+        private_key=private_key,
+        use_ssl=secure
     )
 
 
-def grpc_local(auth_header: Optional[str] = None) -> Provider:
+def grpc_devnet(auth_header: Optional[str] = None, private_key: Optional[str] = None, secure: Optional[bool] = False) -> Provider:
+    host, port = constants.get_devnet_endpoint(constants.ConnectionType.GRPC, secure=secure)
+    return GrpcProvider(
+        host=host,
+        port=port,
+        private_key=private_key,
+        auth_header=auth_header,
+        use_ssl=secure
+    )
+
+
+def grpc_local(auth_header: Optional[str] = None, private_key: Optional[str] = None) -> Provider:
     return GrpcProvider(
         host=constants.LOCAL_API_GRPC_HOST,
         port=constants.LOCAL_API_GRPC_PORT,
+        private_key=private_key,
         auth_header=auth_header,
+        use_ssl=False
     )

--- a/bxsolana/provider/grpc.py
+++ b/bxsolana/provider/grpc.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import Optional
 
 from grpclib import client
@@ -22,7 +23,7 @@ class GrpcProvider(Provider):
 
     def __init__(
         self,
-        host: str = constants.MAINNET_API_UK_GRPC_HOST,
+        host: str = constants.MAINNET_API_NY_GRPC_HOST,
         port: int = constants.MAINNET_API_GRPC_PORT,
         private_key: Optional[str] = None,
         auth_header: Optional[str] = None,
@@ -30,6 +31,8 @@ class GrpcProvider(Provider):
         *,
         timeout: Optional[float] = None,
     ):
+        if use_ssl:
+            warnings.warn(constants.warning_tls_slowdown)
         self._host = host
         self._port = port
         self._use_ssl = use_ssl

--- a/bxsolana/provider/http.py
+++ b/bxsolana/provider/http.py
@@ -1,5 +1,6 @@
 import os
 from typing import Type, AsyncGenerator, Optional, TYPE_CHECKING, List, Any
+import warnings
 
 import aiohttp
 
@@ -38,6 +39,9 @@ class HttpProvider(Provider):
         auth_header: Optional[str] = None,
         private_key: Optional[str] = None,
     ):
+        if endpoint.startswith("https://"):
+            warnings.warn(constants.warning_tls_slowdown)
+
         self._endpoint = f'{endpoint}/api/v1'
         self._endpoint_v2 = f'{endpoint}/api/v2'
         if auth_header is None:

--- a/bxsolana/provider/http.py
+++ b/bxsolana/provider/http.py
@@ -35,7 +35,7 @@ class HttpProvider(Provider):
     # noinspection PyMissingConstructor
     def __init__(
         self,
-        endpoint: str = constants.MAINNET_API_UK_HTTP,
+        endpoint: str = constants.MAINNET_API_NY_HTTP,
         auth_header: Optional[str] = None,
         private_key: Optional[str] = None,
     ):

--- a/bxsolana/provider/http.py
+++ b/bxsolana/provider/http.py
@@ -35,7 +35,7 @@ class HttpProvider(Provider):
     # noinspection PyMissingConstructor
     def __init__(
         self,
-        endpoint: str = constants.MAINNET_API_NY_HTTP,
+        endpoint: str = constants.get_http_endpoint(constants.Region.NY, secure=False),
         auth_header: Optional[str] = None,
         private_key: Optional[str] = None,
     ):
@@ -47,7 +47,16 @@ class HttpProvider(Provider):
         if auth_header is None:
             auth_header = os.environ["AUTH_HEADER"]
 
-        self._session = aiohttp.ClientSession()
+        connector = aiohttp.TCPConnector(
+            keepalive_timeout=0,
+            enable_cleanup_closed=True,
+            limit=200,
+            limit_per_host=200,
+        )
+
+        self._session = aiohttp.ClientSession(
+            connector=connector,
+        )
         self._session.headers["authorization"] = auth_header
         self._session.headers["x-sdk"] = NAME
         self._session.headers["x-sdk-version"] = VERSION
@@ -1119,28 +1128,26 @@ def serialize_projects(projects: List[proto.Project]) -> str:
     return serialize_list("projects", [project.name for project in projects])
 
 
-def http(region: Optional[constants.Region] = None) -> Provider:
-    # default to UK if no region specified
-    if region is None or region == constants.Region.UK:
-        endpoint = constants.MAINNET_API_UK_HTTP
-    elif region == constants.Region.NY:
-        endpoint = constants.MAINNET_API_NY_HTTP
-    else:
-        raise ValueError(f"Unsupported region: {region}")
+def http(region: Optional[constants.Region] = constants.Region.NY, secure: Optional[bool] = False) -> Provider:
+    endpoint = constants.get_http_endpoint(region, secure=secure)
+    return HttpProvider(endpoint=endpoint) 
 
+def http_pump_ny(secure: Optional[bool] = False) -> Provider:
+    endpoint = constants.get_http_endpoint(constants.Region.NY, secure=secure, pump=True)
     return HttpProvider(endpoint=endpoint)
 
-def http_testnet() -> Provider:
-    return HttpProvider(endpoint=constants.TESTNET_API_HTTP)
+def http_pump_uk(secure: Optional[bool] = False) -> Provider:
+    endpoint = constants.get_http_endpoint(constants.Region.UK, secure=secure, pump=True)
+    return HttpProvider(endpoint=endpoint)
 
+def http_testnet(secure: Optional[bool] = False) -> Provider:
+    endpoint = constants.get_testnet_endpoint(constants.ConnectionType.HTTP, secure=secure)
+    return HttpProvider(endpoint=endpoint)
 
-def http_devnet() -> Provider:
-    return HttpProvider(endpoint=constants.DEVNET_API_HTTP)
-
-
-def http_pump_ny() -> Provider:
-    return HttpProvider(endpoint=constants.MAINNET_API_PUMP_NY_HTTP)
-
+def http_devnet(secure: Optional[bool] = False) -> Provider:
+    endpoint = constants.get_devnet_endpoint(constants.ConnectionType.HTTP, secure=secure)
+    return HttpProvider(endpoint=endpoint)
 
 def http_local() -> Provider:
-    return HttpProvider(endpoint=constants.LOCAL_API_HTTP)
+    endpoint = constants.get_local_endpoint(constants.ConnectionType.HTTP)
+    return HttpProvider(endpoint=endpoint)

--- a/bxsolana/provider/ws.py
+++ b/bxsolana/provider/ws.py
@@ -1,6 +1,7 @@
 import dataclasses
 import os
 import re
+import warnings
 from typing import AsyncGenerator, Dict, Optional, TYPE_CHECKING, Type
 
 import jsonrpc
@@ -37,6 +38,9 @@ class WsProvider(Provider):
         private_key: Optional[str] = None,
         request_timeout_s: Optional[int] = None,
     ):
+        if endpoint.startswith("wss://"):
+            warnings.warn(constants.warning_tls_slowdown)
+            
         self._endpoint = endpoint
 
         if auth_header is None:

--- a/bxsolana/provider/ws.py
+++ b/bxsolana/provider/ws.py
@@ -7,6 +7,8 @@ from typing import AsyncGenerator, Dict, Optional, TYPE_CHECKING, Type
 import jsonrpc
 from . import jsonrpc_patch  # noqa: F401, Used for side-effect patching
 from solders import keypair as kp # pyre-ignore[21]: module is too hard to find
+import asyncio
+import websockets
 
 from . import Provider, constants
 from .. import transaction
@@ -33,15 +35,19 @@ class WsProvider(Provider):
 
     def __init__(
         self,
-        endpoint: str = constants.MAINNET_API_NY_WS,
+        endpoint: str = constants.get_ws_endpoint(constants.Region.NY, secure=False),
         auth_header: Optional[str] = None,
         private_key: Optional[str] = None,
         request_timeout_s: Optional[int] = None,
+        keep_alive_ping_interval: Optional[int] = 30,
     ):
         if endpoint.startswith("wss://"):
             warnings.warn(constants.warning_tls_slowdown)
             
         self._endpoint = endpoint
+
+        self._ping_interval = keep_alive_ping_interval
+        self._keep_alive_task = None
 
         if auth_header is None:
             auth_header = os.environ["AUTH_HEADER"]
@@ -66,11 +72,32 @@ class WsProvider(Provider):
 
     async def connect(self):
         await self._ws.connect()
+        self._keep_alive_task = asyncio.create_task(self._ping_loop())
+
+    async def _ping_loop(self):
+        """Send periodic pings to keep connection alive"""
+        if self._ping_interval is None:
+            return 
+        while True:
+            try:
+                await asyncio.sleep(self._ping_interval)
+                if hasattr(self._ws, '_websocket') and self._ws._websocket:
+                    await self._ws._websocket.ping()
+            except (websockets.exceptions.ConnectionClosed, AttributeError):
+                break
+            except Exception:
+                continue
 
     def private_key(self) -> Optional[kp.Keypair]:
         return self._private_key
-
+    
     async def close(self):
+        if self._keep_alive_task:
+            self._keep_alive_task.cancel()
+            try:
+                await self._keep_alive_task
+            except asyncio.CancelledError:
+                pass
         await self._ws.close()
 
     async def _unary_unary(
@@ -120,32 +147,29 @@ def _ws_endpoint(route: str) -> str:
     return route.split("/")[-1]
 
 
-def ws(region: Optional[constants.Region] = None) -> WsProvider:
-    # Default to UK if no region specified
-    if region is None or region == constants.Region.UK:
-        endpoint = constants.MAINNET_API_UK_WS
-    elif region == constants.Region.NY:
-        endpoint = constants.MAINNET_API_NY_WS
-    else:
-        raise ValueError(f"Unsupported region: {region}")
-
-    # Pass the appropriate endpoint to WsProvider
+def ws(region: Optional[constants.Region] = constants.Region.NY, secure: Optional[bool] = False) -> WsProvider:
+    endpoint = constants.get_ws_endpoint(region, secure=secure)
     return WsProvider(endpoint=endpoint)
 
-def ws_pump_ny() -> Provider:
-    return WsProvider(endpoint=constants.MAINNET_API_PUMP_NY_WS)
+def ws_pump_ny(secure: Optional[bool] = False) -> Provider:
+    endpoint = constants.get_ws_endpoint(constants.Region.NY, secure=secure, pump=True)
+    return WsProvider(endpoint=endpoint)
 
+def ws_pump_uk(secure: Optional[bool] = False) -> Provider:
+    endpoint = constants.get_ws_endpoint(constants.Region.UK, secure=secure, pump=True)
+    return WsProvider(endpoint=endpoint)
 
-def ws_testnet() -> Provider:
-    return WsProvider(endpoint=constants.TESTNET_API_WS)
+def ws_testnet(secure: Optional[bool] = False) -> Provider:
+    endpoint = constants.get_testnet_endpoint(constants.ConnectionType.WS, secure=secure)
+    return WsProvider(endpoint=endpoint)
 
-
-def ws_devnet() -> Provider:
-    return WsProvider(endpoint=constants.DEVNET_API_WS)
-
+def ws_devnet(secure: Optional[bool] = False) -> Provider:
+    endpoint = constants.get_devnet_endpoint(constants.ConnectionType.WS, secure=secure)
+    return WsProvider(endpoint=endpoint)
 
 def ws_local() -> Provider:
-    return WsProvider(endpoint=constants.LOCAL_API_WS)
+    endpoint = constants.get_local_endpoint(constants.ConnectionType.WS)
+    return WsProvider(endpoint=endpoint)
 
 
 def _validated_response(response: Dict, response_type: Type["T"]) -> "T":

--- a/bxsolana/provider/ws.py
+++ b/bxsolana/provider/ws.py
@@ -33,7 +33,7 @@ class WsProvider(Provider):
 
     def __init__(
         self,
-        endpoint: str = constants.MAINNET_API_UK_WS,
+        endpoint: str = constants.MAINNET_API_NY_WS,
         auth_header: Optional[str] = None,
         private_key: Optional[str] = None,
         request_timeout_s: Optional[int] = None,

--- a/test/integration/test_grpc.py
+++ b/test/integration/test_grpc.py
@@ -1,5 +1,10 @@
 import unittest
 import asyncio
+import sys
+import os
+# Use local changes when testing
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+
 from bxsolana import provider
 from bxsolana_trader_proto import api as proto
 
@@ -11,7 +16,7 @@ class TestGRPC(unittest.TestCase):
         p = provider.grpc_pump_ny()
         await p.connect()
         request = proto.GetPumpFunAmmSwapStreamRequest(
-            pools=["6WwcmiRJFPDNdFmtgVQ8eY1zxMzLKGLrYuUtRy4iZmye"]
+            pools=["Ef7wUrbarRXHNMMgBs8cstSkzRttnstjMsniaq7zMp6j"]
         )
         
         try:

--- a/test/integration/test_http.py
+++ b/test/integration/test_http.py
@@ -1,0 +1,23 @@
+import unittest
+import asyncio
+import sys
+import os
+# Use local changes when testing
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+
+from bxsolana import provider
+from bxsolana_trader_proto import api as proto
+
+class TestGRPC(unittest.TestCase):
+    def test_get_recent_blockhash(self):
+        asyncio.run(self._test_impl())
+        
+    async def _test_impl(self):
+        p = provider.http()
+        await p.connect()  # Add this
+        try:
+            request = proto.GetRecentBlockHashRequest()
+            response = await p.get_recent_block_hash(request)
+            print(response)
+        finally:
+            await p.close()

--- a/test/integration/test_ws.py
+++ b/test/integration/test_ws.py
@@ -1,5 +1,10 @@
 import unittest
 import asyncio
+import sys
+import os
+# Use local changes when testing
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+
 from bxsolana import provider
 from bxsolana_trader_proto import api as proto
 
@@ -11,7 +16,7 @@ class TestGRPC(unittest.TestCase):
         p = provider.ws_pump_ny()
         await p.connect()
         request = proto.GetPumpFunAmmSwapStreamRequest(
-            pools=["6WwcmiRJFPDNdFmtgVQ8eY1zxMzLKGLrYuUtRy4iZmye"]
+            pools=["Ef7wUrbarRXHNMMgBs8cstSkzRttnstjMsniaq7zMp6j"]
         )
         
         try:


### PR DESCRIPTION
#### Endpoints by Region

* constants.py has been rewritten to get the endpoint via the `Region` type.
  * For example: get_grpc_endpoint(Region.LA) 
* Constructor methods default to NY region with no TLS
  * For example: provider.http() defaults to NY with insecure connection type.

#### Provider Constructor Updates

* Functions used to create providers have been updated to:

  * Check whether the endpoint uses TLS and issue a warning about potential performance implications.

#### Connection Management

**gRPC:**

* Added the following configurations to the grpc connection management
  * _keepalive_permit_without_calls set to true (maintain quiet streams)
  * _keepalive_time set to ping every 15 seconds
  * _keepalive_timeout set to 5 seconds

**HTTP:**
* Added the following configurations to the HTTP connection management
  * keep_alive_timeout set to 0 for MaxIdleTime set to infinity using aiohttp.TCPConnector.
  * limits for open connections have been increased to large number (200 per host)

**Web Socket**

* Added the following configurations to the Web Socket connection management
  * Added a ping loop in the background that pings the connection every 15 seconds to keep alive, similar to our other SDKs.